### PR TITLE
Add browse-only explorer UI for ActiveQuery

### DIFF
--- a/app/controllers/active_query/gui/queries_controller.rb
+++ b/app/controllers/active_query/gui/queries_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ActiveQuery
+  module GUI
+    class QueriesController < ActionController::Base
+      def index
+        render json: grouped_queries
+      end
+
+      private
+
+      def grouped_queries
+        ActiveQuery::Base.registry.group_by { |klass| namespace_for(klass) }.map do |namespace, klasses|
+          {
+            namespace: namespace,
+            query_objects: klasses.map { |k| query_object_payload(k) }
+          }
+        end
+      end
+
+      def query_object_payload(klass)
+        {
+          class_name: klass.name,
+          source_location: source_location_for(klass),
+          queries: (klass.queries || []).map do |q|
+            {
+              name: q[:name],
+              description: q[:description],
+              params: (q[:args_def] || {}).map do |name, config|
+                {
+                  name: name,
+                  type: config[:type]&.name,
+                  optional: config[:optional] || false,
+                  default: config[:default]
+                }.compact
+              end
+            }
+          end
+        }
+      end
+
+      def source_location_for(klass)
+        file, line = Object.const_source_location(klass.name)
+        return nil unless file
+
+        { file: file, line: line }
+      end
+
+      def namespace_for(klass)
+        name = klass.name.to_s
+        last_separator = name.rindex("::")
+        last_separator ? name[0...last_separator] : ""
+      end
+    end
+  end
+end

--- a/app/controllers/active_query/gui/queries_controller.rb
+++ b/app/controllers/active_query/gui/queries_controller.rb
@@ -15,7 +15,8 @@ module ActiveQuery
       private
 
       def grouped_queries
-        ActiveQuery::Base.registry.group_by { |klass| namespace_for(klass) }.map do |namespace, klasses|
+        query_classes = ActiveQuery::Base.registry.select { |k| k.is_a?(Class) }
+        query_classes.group_by { |klass| namespace_for(klass) }.map do |namespace, klasses|
           {
             namespace: namespace,
             query_objects: klasses.map { |k| query_object_payload(k) }

--- a/app/controllers/active_query/gui/queries_controller.rb
+++ b/app/controllers/active_query/gui/queries_controller.rb
@@ -3,8 +3,13 @@
 module ActiveQuery
   module GUI
     class QueriesController < ActionController::Base
+      layout false
+
       def index
-        render json: grouped_queries
+        respond_to do |format|
+          format.html
+          format.json { render json: grouped_queries }
+        end
       end
 
       private

--- a/app/views/active_query/gui/queries/index.html.erb
+++ b/app/views/active_query/gui/queries/index.html.erb
@@ -1,0 +1,549 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ActiveQuery Explorer</title>
+  <style>
+    :root {
+      --bg: #f8f9fa;
+      --surface: #ffffff;
+      --border: #dee2e6;
+      --text: #212529;
+      --text-muted: #6c757d;
+      --primary: #4361ee;
+      --primary-light: #eef0ff;
+      --tag-bg: #e9ecef;
+      --code-bg: #f1f3f5;
+      --success: #2b9348;
+      --sidebar-w: 280px;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+    }
+
+    /* Layout */
+    .layout {
+      display: flex;
+      height: 100vh;
+    }
+
+    /* Sidebar */
+    .sidebar {
+      width: var(--sidebar-w);
+      min-width: var(--sidebar-w);
+      background: var(--surface);
+      border-right: 1px solid var(--border);
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .sidebar-header {
+      padding: 16px;
+      border-bottom: 1px solid var(--border);
+      font-weight: 600;
+      font-size: 15px;
+      color: var(--primary);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .sidebar-header button {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 4px 8px;
+      cursor: pointer;
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .sidebar-header button:hover {
+      background: var(--bg);
+    }
+
+    .sidebar-nav {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px 0;
+    }
+
+    .namespace-group {
+      margin-bottom: 4px;
+    }
+
+    .namespace-toggle {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      padding: 6px 16px;
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      text-align: left;
+    }
+
+    .namespace-toggle:hover {
+      background: var(--bg);
+    }
+
+    .namespace-toggle .arrow {
+      display: inline-block;
+      width: 16px;
+      font-size: 10px;
+      color: var(--text-muted);
+      transition: transform 0.15s;
+    }
+
+    .namespace-toggle.open .arrow {
+      transform: rotate(90deg);
+    }
+
+    .namespace-children {
+      display: none;
+    }
+
+    .namespace-children.open {
+      display: block;
+    }
+
+    .query-class-link {
+      display: block;
+      padding: 4px 16px 4px 32px;
+      font-size: 13px;
+      color: var(--text-muted);
+      text-decoration: none;
+      cursor: pointer;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .query-class-link:hover,
+    .query-class-link.active {
+      background: var(--primary-light);
+      color: var(--primary);
+    }
+
+    /* Main */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 24px 32px;
+    }
+
+    .main-header {
+      margin-bottom: 24px;
+    }
+
+    .main-header h1 {
+      font-size: 22px;
+      font-weight: 600;
+    }
+
+    .main-header p {
+      color: var(--text-muted);
+      font-size: 14px;
+      margin-top: 4px;
+    }
+
+    /* Query object card */
+    .query-object {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      margin-bottom: 20px;
+    }
+
+    .query-object-header {
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: baseline;
+      gap: 12px;
+    }
+
+    .query-object-header h2 {
+      font-size: 16px;
+      font-weight: 600;
+      font-family: "SF Mono", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    }
+
+    .source-location {
+      font-size: 12px;
+      color: var(--text-muted);
+      font-family: "SF Mono", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+    }
+
+    /* Individual query card */
+    .query-card {
+      border-bottom: 1px solid var(--border);
+    }
+
+    .query-card:last-child {
+      border-bottom: none;
+    }
+
+    .query-card-header {
+      padding: 12px 18px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      user-select: none;
+    }
+
+    .query-card-header:hover {
+      background: var(--bg);
+    }
+
+    .query-card-header .arrow {
+      font-size: 10px;
+      color: var(--text-muted);
+      display: inline-block;
+      width: 14px;
+      transition: transform 0.15s;
+    }
+
+    .query-card-header.open .arrow {
+      transform: rotate(90deg);
+    }
+
+    .query-name {
+      font-weight: 600;
+      font-size: 14px;
+      font-family: "SF Mono", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+      color: var(--primary);
+    }
+
+    .query-description {
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    .query-param-count {
+      font-size: 11px;
+      background: var(--tag-bg);
+      padding: 1px 7px;
+      border-radius: 10px;
+      color: var(--text-muted);
+      margin-left: auto;
+      white-space: nowrap;
+    }
+
+    .query-card-body {
+      display: none;
+      padding: 0 18px 16px 42px;
+    }
+
+    .query-card-body.open {
+      display: block;
+    }
+
+    /* Params table */
+    .params-section h4 {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+
+    .params-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+
+    .params-table th {
+      text-align: left;
+      padding: 6px 12px 6px 0;
+      font-weight: 600;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .params-table td {
+      padding: 6px 12px 6px 0;
+      border-bottom: 1px solid var(--bg);
+    }
+
+    .params-table .param-name {
+      font-family: "SF Mono", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+      font-weight: 500;
+    }
+
+    .type-tag {
+      display: inline-block;
+      background: var(--code-bg);
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-family: "SF Mono", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+      font-size: 12px;
+    }
+
+    .badge {
+      display: inline-block;
+      font-size: 11px;
+      padding: 1px 6px;
+      border-radius: 3px;
+    }
+
+    .badge-required {
+      background: #fff3cd;
+      color: #856404;
+    }
+
+    .badge-optional {
+      background: #d4edda;
+      color: var(--success);
+    }
+
+    .no-params {
+      font-size: 13px;
+      color: var(--text-muted);
+      font-style: italic;
+    }
+
+    /* Empty state */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--text-muted);
+    }
+
+    .empty-state h2 {
+      font-size: 18px;
+      margin-bottom: 8px;
+      color: var(--text);
+    }
+
+    /* Loading */
+    .loading {
+      text-align: center;
+      padding: 60px;
+      color: var(--text-muted);
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <span>ActiveQuery</span>
+        <button onclick="refresh()" title="Reload queries">Refresh</button>
+      </div>
+      <nav class="sidebar-nav" id="sidebar-nav"></nav>
+    </aside>
+    <main class="main" id="main">
+      <div class="loading">Loading queries...</div>
+    </main>
+  </div>
+
+  <script>
+    var state = { data: [], activeClass: null };
+
+    function fetchQueries() {
+      var main = document.getElementById("main");
+      main.innerHTML = '<div class="loading">Loading queries...</div>';
+
+      fetch("<%= active_query_gui.queries_path(format: :json) %>")
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          state.data = data;
+          renderSidebar();
+          renderMain();
+        })
+        .catch(function(err) {
+          main.innerHTML = '<div class="empty-state"><h2>Error loading queries</h2><p>' + err.message + '</p></div>';
+        });
+    }
+
+    function refresh() {
+      fetchQueries();
+    }
+
+    function renderSidebar() {
+      var nav = document.getElementById("sidebar-nav");
+      if (state.data.length === 0) {
+        nav.innerHTML = '<div style="padding:16px;color:var(--text-muted);font-size:13px;">No queries found</div>';
+        return;
+      }
+
+      var html = "";
+      state.data.forEach(function(group) {
+        var ns = group.namespace || "(root)";
+        html += '<div class="namespace-group">';
+        html += '<button class="namespace-toggle open" onclick="toggleNamespace(this)">';
+        html += '<span class="arrow">&#9654;</span> ' + escapeHtml(ns);
+        html += '</button>';
+        html += '<div class="namespace-children open">';
+        group.query_objects.forEach(function(qo) {
+          var shortName = qo.class_name.split("::").pop();
+          html += '<a class="query-class-link" data-class="' + escapeAttr(qo.class_name) + '" onclick="scrollToClass(\'' + escapeAttr(qo.class_name) + '\')">';
+          html += escapeHtml(shortName);
+          html += '</a>';
+        });
+        html += '</div></div>';
+      });
+      nav.innerHTML = html;
+    }
+
+    function renderMain() {
+      var main = document.getElementById("main");
+
+      if (state.data.length === 0) {
+        main.innerHTML = '<div class="empty-state"><h2>No queries registered</h2><p>Define query objects that include ActiveQuery::Base to see them here.</p></div>';
+        return;
+      }
+
+      var total = 0;
+      state.data.forEach(function(g) {
+        g.query_objects.forEach(function(qo) { total += qo.queries.length; });
+      });
+
+      var html = '<div class="main-header"><h1>Query Explorer</h1>';
+      html += '<p>' + total + ' queries across ' + countClasses() + ' objects</p></div>';
+
+      state.data.forEach(function(group) {
+        group.query_objects.forEach(function(qo) {
+          html += renderQueryObject(qo);
+        });
+      });
+
+      main.innerHTML = html;
+    }
+
+    function renderQueryObject(qo) {
+      var id = qo.class_name.replace(/::/g, "-");
+      var html = '<div class="query-object" id="qo-' + escapeAttr(id) + '">';
+
+      html += '<div class="query-object-header">';
+      html += '<h2>' + escapeHtml(qo.class_name) + '</h2>';
+      if (qo.source_location) {
+        var shortPath = shortenPath(qo.source_location.file);
+        html += '<span class="source-location">' + escapeHtml(shortPath) + ':' + qo.source_location.line + '</span>';
+      }
+      html += '</div>';
+
+      if (qo.queries.length === 0) {
+        html += '<div style="padding:14px 18px;"><span class="no-params">No queries defined</span></div>';
+      } else {
+        qo.queries.forEach(function(q, i) {
+          html += renderQueryCard(q, id + "-" + i);
+        });
+      }
+
+      html += '</div>';
+      return html;
+    }
+
+    function renderQueryCard(q, cardId) {
+      var paramCount = q.params ? q.params.length : 0;
+      var html = '<div class="query-card">';
+
+      html += '<div class="query-card-header" onclick="toggleCard(\'' + cardId + '\')">';
+      html += '<span class="arrow" id="arrow-' + cardId + '">&#9654;</span>';
+      html += '<span class="query-name">:' + escapeHtml(q.name) + '</span>';
+      if (q.description) {
+        html += '<span class="query-description">' + escapeHtml(q.description) + '</span>';
+      }
+      if (paramCount > 0) {
+        html += '<span class="query-param-count">' + paramCount + ' param' + (paramCount > 1 ? 's' : '') + '</span>';
+      }
+      html += '</div>';
+
+      html += '<div class="query-card-body" id="body-' + cardId + '">';
+      if (paramCount > 0) {
+        html += '<div class="params-section"><h4>Parameters</h4>';
+        html += '<table class="params-table"><thead><tr>';
+        html += '<th>Name</th><th>Type</th><th>Required</th><th>Default</th>';
+        html += '</tr></thead><tbody>';
+        q.params.forEach(function(p) {
+          html += '<tr>';
+          html += '<td class="param-name">' + escapeHtml(p.name) + '</td>';
+          html += '<td><span class="type-tag">' + escapeHtml(p.type || "any") + '</span></td>';
+          html += '<td>';
+          if (p.optional) {
+            html += '<span class="badge badge-optional">optional</span>';
+          } else {
+            html += '<span class="badge badge-required">required</span>';
+          }
+          html += '</td>';
+          html += '<td>' + (p.default != null ? escapeHtml(String(p.default)) : '<span style="color:var(--text-muted)">—</span>') + '</td>';
+          html += '</tr>';
+        });
+        html += '</tbody></table></div>';
+      } else {
+        html += '<span class="no-params">No parameters</span>';
+      }
+      html += '</div>';
+
+      html += '</div>';
+      return html;
+    }
+
+    function toggleCard(cardId) {
+      var body = document.getElementById("body-" + cardId);
+      var header = body.previousElementSibling;
+      body.classList.toggle("open");
+      header.classList.toggle("open");
+    }
+
+    function toggleNamespace(btn) {
+      btn.classList.toggle("open");
+      var children = btn.nextElementSibling;
+      children.classList.toggle("open");
+    }
+
+    function scrollToClass(className) {
+      var id = "qo-" + className.replace(/::/g, "-");
+      var el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+
+      document.querySelectorAll(".query-class-link").forEach(function(link) {
+        link.classList.toggle("active", link.getAttribute("data-class") === className);
+      });
+    }
+
+    function countClasses() {
+      var count = 0;
+      state.data.forEach(function(g) { count += g.query_objects.length; });
+      return count;
+    }
+
+    function shortenPath(path) {
+      var idx = path.indexOf("/app/");
+      return idx >= 0 ? path.substring(idx + 1) : path;
+    }
+
+    function escapeHtml(str) {
+      var div = document.createElement("div");
+      div.appendChild(document.createTextNode(str));
+      return div.innerHTML;
+    }
+
+    function escapeAttr(str) {
+      return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+    }
+
+    fetchQueries();
+  </script>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ActiveQuery::GUI::Engine.routes.draw do
+  resources :queries, only: [:index]
+
+  root to: "queries#index"
+end

--- a/lib/active_query.rb
+++ b/lib/active_query.rb
@@ -13,7 +13,14 @@ module ActiveQuery
 
     class Boolean; end
 
+    @registry = []
+
+    def self.registry
+      @registry
+    end
+
     included do
+      ActiveQuery::Base.registry << self
       infer_model
       @__queries = []
     end

--- a/lib/active_query.rb
+++ b/lib/active_query.rb
@@ -20,7 +20,7 @@ module ActiveQuery
     end
 
     included do
-      ActiveQuery::Base.registry << self
+      ActiveQuery::Base.registry << self unless ActiveQuery::Base.registry.include?(self)
       infer_model
       @__queries = []
     end
@@ -79,6 +79,8 @@ module ActiveQuery
       end
 
       def infer_model
+        return unless self.name
+
         model_class_name = self.name.sub(/::Query$/, '').classify
         return unless const_defined?(model_class_name)
 

--- a/lib/active_query/gui.rb
+++ b/lib/active_query/gui.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ActiveQuery
+  module GUI
+  end
+end
+
+require "active_query/gui/engine" if defined?(Rails::Engine)

--- a/lib/active_query/gui/engine.rb
+++ b/lib/active_query/gui/engine.rb
@@ -7,8 +7,10 @@ module ActiveQuery
 
       initializer "active_query.gui.eager_load_queries" do
         ActiveSupport.on_load(:after_initialize) do
-          queries_path = Rails.root.join("app", "queries")
-          Rails.autoloaders.main.eager_load_dir(queries_path.to_s) if queries_path.exist?
+          %w[queries query_objects].each do |dir|
+            path = Rails.root.join("app", dir)
+            Rails.autoloaders.main.eager_load_dir(path.to_s) if path.exist?
+          end
         end
       end
     end

--- a/lib/active_query/gui/engine.rb
+++ b/lib/active_query/gui/engine.rb
@@ -7,9 +7,19 @@ module ActiveQuery
 
       initializer "active_query.gui.eager_load_queries" do
         ActiveSupport.on_load(:after_initialize) do
-          %w[queries query_objects].each do |dir|
+          query_dirs = %w[queries query_objects]
+
+          # Standard Rails app paths
+          query_dirs.each do |dir|
             path = Rails.root.join("app", dir)
             Rails.autoloaders.main.eager_load_dir(path.to_s) if path.exist?
+          end
+
+          # Packwerk / packs paths (packs/**/app/queries)
+          query_dirs.each do |dir|
+            Dir.glob(Rails.root.join("packs", "**", "app", dir).to_s).each do |path|
+              Rails.autoloaders.main.eager_load_dir(path) if File.directory?(path)
+            end
           end
         end
       end

--- a/lib/active_query/gui/engine.rb
+++ b/lib/active_query/gui/engine.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActiveQuery
+  module GUI
+    class Engine < ::Rails::Engine
+      isolate_namespace ActiveQuery::GUI
+
+      initializer "active_query.gui.eager_load_queries" do
+        ActiveSupport.on_load(:after_initialize) do
+          queries_path = Rails.root.join("app", "queries")
+          Rails.autoloaders.main.eager_load_dir(queries_path.to_s) if queries_path.exist?
+        end
+      end
+    end
+  end
+end

--- a/spec/active/gui/query_discovery_spec.rb
+++ b/spec/active/gui/query_discovery_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Query Discovery' do
+  describe 'grouped queries from registry' do
+    let(:grouped) do
+      ActiveQuery::Base.registry.group_by { |klass|
+        name = klass.name.to_s
+        last_separator = name.rindex("::")
+        last_separator ? name[0...last_separator] : ""
+      }.map do |namespace, klasses|
+        {
+          namespace: namespace,
+          query_objects: klasses.map { |k| build_payload(k) }
+        }
+      end
+    end
+
+    def build_payload(klass)
+      {
+        class_name: klass.name,
+        queries: (klass.queries || []).map do |q|
+          {
+            name: q[:name],
+            description: q[:description],
+            params: (q[:args_def] || {}).map do |name, config|
+              {
+                name: name,
+                type: config[:type]&.name,
+                optional: config[:optional] || false,
+                default: config[:default]
+              }.compact
+            end
+          }
+        end
+      }
+    end
+
+    it 'groups queries by namespace' do
+      namespaces = grouped.map { |g| g[:namespace] }
+      expect(namespaces).to include('DummyModels')
+    end
+
+    it 'includes query objects within their namespace' do
+      dummy_group = grouped.find { |g| g[:namespace] == 'DummyModels' }
+      class_names = dummy_group[:query_objects].map { |qo| qo[:class_name] }
+      expect(class_names).to include('DummyModels::Query')
+    end
+
+    it 'includes query details with name and description' do
+      dummy_group = grouped.find { |g| g[:namespace] == 'DummyModels' }
+      query_obj = dummy_group[:query_objects].find { |qo| qo[:class_name] == 'DummyModels::Query' }
+      query_names = query_obj[:queries].map { |q| q[:name] }
+
+      expect(query_names).to include(:count)
+      expect(query_names).to include(:by_name)
+    end
+
+    it 'includes parameter definitions for queries with args' do
+      dummy_group = grouped.find { |g| g[:namespace] == 'DummyModels' }
+      query_obj = dummy_group[:query_objects].find { |qo| qo[:class_name] == 'DummyModels::Query' }
+      by_name = query_obj[:queries].find { |q| q[:name] == :by_name }
+
+      expect(by_name[:params]).to include(
+        hash_including(name: :name, type: 'String', optional: false)
+      )
+    end
+
+    it 'returns empty params for queries without args' do
+      dummy_group = grouped.find { |g| g[:namespace] == 'DummyModels' }
+      query_obj = dummy_group[:query_objects].find { |qo| qo[:class_name] == 'DummyModels::Query' }
+      count = query_obj[:queries].find { |q| q[:name] == :count }
+
+      expect(count[:params]).to eq([])
+    end
+  end
+end

--- a/spec/active/gui/query_discovery_spec.rb
+++ b/spec/active/gui/query_discovery_spec.rb
@@ -4,8 +4,10 @@ require 'spec_helper'
 
 RSpec.describe 'Query Discovery' do
   describe 'grouped queries from registry' do
+    let(:query_classes) { ActiveQuery::Base.registry.select { |k| k.is_a?(Class) } }
+
     let(:grouped) do
-      ActiveQuery::Base.registry.group_by { |klass|
+      query_classes.group_by { |klass|
         name = klass.name.to_s
         last_separator = name.rindex("::")
         last_separator ? name[0...last_separator] : ""
@@ -73,6 +75,10 @@ RSpec.describe 'Query Discovery' do
       count = query_obj[:queries].find { |q| q[:name] == :count }
 
       expect(count[:params]).to eq([])
+    end
+
+    it 'excludes intermediary modules from query classes' do
+      expect(query_classes).to all(satisfy { |k| k.is_a?(Class) })
     end
   end
 end

--- a/spec/active/registry_spec.rb
+++ b/spec/active/registry_spec.rb
@@ -14,5 +14,18 @@ RSpec.describe 'Registry' do
         klass.ancestors.include?(ActiveQuery::Base)
       })
     end
+
+    it 'registers classes that include ActiveQuery::Base through an intermediary concern' do
+      intermediary = Module.new do
+        extend ActiveSupport::Concern
+        include ActiveQuery::Base
+      end
+
+      query_class = Class.new do
+        include intermediary
+      end
+
+      expect(ActiveQuery::Base.registry).to include(query_class)
+    end
   end
 end

--- a/spec/active/registry_spec.rb
+++ b/spec/active/registry_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Registry' do
+  describe '.registry' do
+    it 'returns an array of classes that include ActiveQuery::Base' do
+      expect(ActiveQuery::Base.registry).to be_an(Array)
+      expect(ActiveQuery::Base.registry).to include(DummyModels::Query)
+    end
+
+    it 'only contains classes that include ActiveQuery::Base' do
+      expect(ActiveQuery::Base.registry).to all(satisfy { |klass|
+        klass.ancestors.include?(ActiveQuery::Base)
+      })
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a self-contained single-page HTML view at the engine root for browsing all registered query objects
- Updates the controller to serve HTML (browse UI) and JSON (API) via `respond_to`
- Zero external dependencies — inline CSS and vanilla JS, no asset pipeline needed

**Depends on:** #22 (registry), #23 (engine skeleton)

## UI Features

- **Sidebar:** Collapsible namespace tree for navigating query objects
- **Query object cards:** Class name, source file location
- **Expandable query cards:** Name, description, parameter table (type, required/optional, default)
- **Refresh button** to reload without page navigation

## Screenshot-equivalent layout

```
┌──────────────┬──────────────────────────────────────┐
│ ActiveQuery  │  DummyModels::Query                  │
│              │  app/queries/dummy_models/query.rb:3  │
│ ▼ DummyModels│                                      │
│   Query      │  ▶ :count  "Returns DummyModel count"│
│              │  ▼ :by_name "Returns models by name" │
│              │    Parameters:                        │
│              │    name  String  required  —           │
│              │                                       │
│              │  ▶ :count_resolver ...                │
│              │  ▶ :by_name_resolver ...              │
└──────────────┴──────────────────────────────────────┘
```

## Files changed

| File | Change |
|---|---|
| `app/controllers/.../queries_controller.rb` | Add `respond_to` for HTML + JSON |
| `app/views/.../queries/index.html.erb` | New — self-contained explorer page |

## Test plan

- [x] All 47 existing tests pass
- [ ] Manual verification: mount engine in a Rails app, visit `/active_query`, confirm sidebar and cards render

🤖 Generated with [Claude Code](https://claude.com/claude-code)